### PR TITLE
Turn on vm.overcommit_memory on GCP builder

### DIFF
--- a/run-files/gcloud/ci-setup.sh
+++ b/run-files/gcloud/ci-setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -eux
+sysctl vm.overcommit_memory=1

--- a/src/ci.ml
+++ b/src/ci.ml
@@ -81,6 +81,7 @@ let can_build =
   | `Production ->
     any [
       username "admin";
+      username "github:rneugeba";
       github_org "linuxkit";
     ]
 


### PR DESCRIPTION
This also adds a script that can be used to override the builder's behaviour, so we don't have to generate a fresh GCP image every time we want to change something.

/cc @rneugeba 

