### PR TITLE
Improve fetching of results

### DIFF
--- a/run-files/gcloud/ci-setup.sh
+++ b/run-files/gcloud/ci-setup.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 set -eux
+mkdir -p /tmp/build/test/_results /tmp/build/artifacts
 sysctl vm.overcommit_memory=1

--- a/src/linuxkit_build.ml
+++ b/src/linuxkit_build.ml
@@ -268,9 +268,9 @@ module Builder = struct
     ] in
     Live_log.log log "Fetching results";
     let output = Live_log.write log in
-    Lwt.catch
+    Lwt.try_bind
+      (fun () -> Process.run ~cwd:tmpdir ~log ~switch ~output ("", Array.of_list cmd))
       (fun () ->
-         Process.run ~cwd:tmpdir ~log ~switch ~output ("", Array.of_list cmd) >>= fun () ->
          match status with
          | Ok () -> Lwt.return ()
          | Error ex -> Lwt.fail ex


### PR DESCRIPTION
Was giving distracting warnings about failing to fetch the results when the build failed.