### PR TITLE
Fix `docker build`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 #FROM datakit/ci:latest AS build-env
-FROM datakit/ci@sha256:1521fc30ca20eee476c7bb80b3b758e60a38e4ea85a28b17bcb1036bf581af27 AS build-env
+FROM datakit/ci@sha256:daecb5fa1e017c39323d39bebfc0e6f94762452f46c29aafe115e7270166d692 AS build-env
 
 ARG CONFIG=dkciCI
 ADD . /src
 WORKDIR /src
-RUN sudo chown opam .
+RUN sudo chown -R opam /src
 RUN opam config exec make
 
 FROM alpine:3.5
@@ -37,4 +37,4 @@ USER root
 ENTRYPOINT ["/usr/local/bin/ci"]
 CMD []
 ADD run-files/gcloud /gcloud
-COPY --from=build-env /src/ci.native /usr/local/bin/ci
+COPY --from=build-env /src/_build/default/src/ci.exe /usr/local/bin/ci


### PR DESCRIPTION
- Update to latest datakit/ci image (to use datakit-client.0.11.0);
- Use a recursive chown (needed by jbuilder); and
- Fix executable path (has moved with swtich to jbuilder)

Signed-off-by: Thomas Gazagnaire <thomas@gazagnaire.org>