### PR TITLE
Add Docker Registry to the stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,11 @@ services:
       # The location of the local repositories to monitor.
       - './local/linuxkit:/linuxkit-src'
       - './local/linuxkit-ci:/linuxkit-ci-src'
+  registry:
+    restart: always
+    image: 'registry:2.6.1'
+    ports:
+      - '5000:5000'
 
 secrets:
   gcp-key.json:

--- a/prod.yml
+++ b/prod.yml
@@ -43,6 +43,11 @@ services:
   redis:
     command: redis-server --save 60 1
     image: 'redis:latest'
+  registry:
+    restart: always
+    image: 'registry:2.6.1'
+    ports:
+      - '5000:5000'
 
 volumes:
   ci-secrets:


### PR DESCRIPTION
This can be used by the linuxkit build as a staging
area for images/packages that have been changed in the
commit under test.

Signed-off-by: Dave Tucker <dt@docker.com>