### PR TITLE
Use custom-2-5120 as recommended by Google

### DIFF
--- a/run-files/gcloud/create.py
+++ b/run-files/gcloud/create.py
@@ -16,7 +16,7 @@ logging.info("Using source disk image %s", source_disk_image)
 
 config = {
         'name': name,
-        'machineType': 'zones/europe-west1-b/machineTypes/n1-standard-1',
+        'machineType': 'zones/europe-west1-b/machineTypes/custom-2-5120',
         'disks': [
             {
                 'boot': True,


### PR DESCRIPTION
It seems our n1-standard-1's are overutilized.
The recommendation is 2 vCPUs and 5GB of RAM

Signed-off-by: Dave Tucker <dt@docker.com>