### PR TITLE
Re-add rn to rebuild ACL

### DIFF
--- a/src/ci.ml
+++ b/src/ci.ml
@@ -107,6 +107,7 @@ let can_build =
     any [
       username "admin";
       username "github:samoht";
+      username "github:rn";
       github_org "linuxkit";
     ]
 


### PR DESCRIPTION
It's not detecting org membership for some reason.