### PR TITLE
Use system ca-certificates for Python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN sudo chown -R opam /src
 RUN opam config exec make
 
 FROM alpine:3.5
+ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
 RUN apk update && apk add \
 	libev \
 	docker \


### PR DESCRIPTION
Otherwise, it fails with:

    requests.exceptions.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:661)

/cc @justincormack 