### PR TITLE
Use linuxkit to define CI workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ local
 *~
 *.install
 *.pyc
+*.img*
+*-kernel
+*-cmdline
+*-state

--- a/build-workers.sh
+++ b/build-workers.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+TIMESTAMP=$(date "+%Y-%m-%d")
+moby build -output gcp worker.yml
+linuxkit push gcp -bucket linuxkit-images -family linuxkit-ci-builder -img-name "linuxkit-ci-builder-${TIMESTAMP}" worker.img.tar.gz

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -1,0 +1,13 @@
+DIRS = $(shell find . -type d -depth 1)
+.PHONY: clean dirs $(DIRS)
+
+push:
+	@set -e; for d in $(DIRS); do make -C "$$d"; done
+
+tag:
+	@set -e; for d in $(DIRS); do make -C "$$d" tag; done
+
+hash:
+	@set -e; for d in $(DIRS); do make -C "$$d" hash; done
+
+clean: ;

--- a/pkg/package.mk
+++ b/pkg/package.mk
@@ -1,0 +1,46 @@
+.PHONY: tag push
+default: push
+
+ORG?=linuxkitci
+HASH?=$(shell git ls-tree HEAD -- ../$(notdir $(CURDIR)) | awk '{print $$3}')
+BASE_DEPS=Dockerfile Makefile
+
+# Add '-dirty' to hash if the repository is not clean. make does not
+# concatenate strings without spaces, so we use the documented trick
+# of replacing the space with nothing.
+DIRTY=$(shell git diff-index --quiet HEAD --; echo $$?)
+ifneq ($(DIRTY),0)
+HASH+=-dirty
+nullstring :=
+space := $(nullstring) $(nullstring)
+TAG=$(subst $(space),,$(HASH))
+else
+TAG=$(HASH)
+endif
+
+# Get a release tag, if present
+RELEASE=$(shell git tag -l --points-at HEAD)
+
+ifndef $(NETWORK)
+NET_OPT=
+else
+NET_OPT=--network=none
+endif
+
+tag: $(BASE_DEPS) $(DEPS)
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(TAG) || \
+	docker build $(NET_OPT) -t $(ORG)/$(IMAGE):$(TAG) .
+
+push: tag
+ifneq ($(DIRTY),0)
+	$(error Your repository is not clean. Will not push package image.)
+endif
+	DOCKER_CONTENT_TRUST=1 docker pull $(ORG)/$(IMAGE):$(TAG) || \
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(TAG)
+ifneq ($(RELEASE),)
+	docker tag $(ORG)/$(IMAGE):$(TAG) $(ORG)/$(IMAGE):$(RELEASE)	
+	DOCKER_CONTENT_TRUST=1 docker push $(ORG)/$(IMAGE):$(RELEASE)
+endif
+
+hash:
+	@echo $(ORG)/$(IMAGE):$(TAG)

--- a/pkg/sshd/Dockerfile
+++ b/pkg/sshd/Dockerfile
@@ -1,0 +1,18 @@
+FROM linuxkit/alpine:87a0cd10449d72f374f950004467737dbf440630 as alpine
+
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk
+RUN apk add --no-cache --initdb -p /out \
+    git \
+    make \
+    expect \
+    qemu-system-x86_64 \
+    qemu-img \
+    && true
+RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+
+FROM linuxkit/docker-ce:9e125aa533108731d11f6d7ec17aba6ded0cb4eb as docker
+
+FROM linuxkit/sshd:505a985d7bd7a90f15eca9cb4dc6ec92789d51a0
+
+COPY --from=alpine /out /
+COPY --from=docker /usr/bin/docker /usr/bin

--- a/pkg/sshd/Makefile
+++ b/pkg/sshd/Makefile
@@ -1,0 +1,2 @@
+IMAGE=sshd
+include ../package.mk

--- a/worker.yml
+++ b/worker.yml
@@ -1,0 +1,82 @@
+kernel:
+  image: linuxkit/kernel:4.9.39
+  cmdline: "console=tty0 console=ttyS0"
+init:
+  - linuxkit/init:838b772355a8690143b37de1cdd4ac5db725271f
+  - linuxkit/runc:d5cbeb95bdafedb82ad2cf11cff1a5da7fcae630
+  - linuxkit/containerd:e33e0534d6fca88e1eb86897a1ea410b4a5d722e
+  - linuxkit/ca-certificates:67acf038c44bb191ebb704ec7bb39a1524052cdf
+  - linuxkit/getty:894eef1e5f62f3bc31de8ffaff2b6c0e093c4595
+onboot:
+  - name: sysctl
+    image: linuxkit/sysctl:d1a43c7c91e92374766f962dc8534cf9508756b0
+  - name: sysfs
+    image: linuxkit/sysfs:006a65b30cfdd9d751d7ab042fde7eca2c3bc9dc
+  - name: binfmt
+    image: linuxkit/binfmt:0bde4ebd422099f45c5ee03217413523ad2223e5
+  - name: format
+    image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
+  - name: mount
+    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    command: ["/usr/bin/mountie", "/var/lib/docker"]
+  - name: format
+    image: linuxkit/format:efafddf9bc6165b5efaf09c532c15a1100a10e61
+  - name: mount
+    image: linuxkit/mount:54990a6a69cb3ead4da8a9c1f0b651e27aea8d3f
+    command: ["/usr/bin/mountie", "/var/tmp"]
+  - name: dhcpcd
+    image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+  - name: metadata
+    image: linuxkit/metadata:f5d4299909b159db35f72547e4ae70bd76c42c6c
+services:
+  - name: rngd
+    image: linuxkit/rngd:1516d5d70683a5d925fe475eb1b6164a2f67ac3b
+  - name: dhcpcd
+    image: linuxkit/dhcpcd:17423c1ccced74e3c005fd80486e8177841fe02b
+  - name: ntpd
+    image: linuxkit/openntpd:2874b66c9fa51fa5b4d11c8b50441eb94ee22a5a
+  - name: docker
+    image: docker:17.06.0-ce-dind
+    capabilities:
+     - all
+    net: host
+    mounts:
+     - type: cgroup
+       options: ["rw","nosuid","noexec","nodev","relatime"]
+    binds:
+     - /var/lib/docker:/var/lib/docker
+     - /var/run:/var/run
+     - /lib/modules:/lib/modules
+     - /etc/docker/daemon.json:/etc/docker/daemon.json
+     - /etc/resolv.conf:/etc/resolv.conf
+    command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
+  - name: sshd
+    image: linuxkitci/sshd:54ec6e816b6ea6ea5cab78609f7e7c31d0170d48
+    binds:
+      - /var/config/ssh/authorized_keys:/root/.ssh/authorized_keys
+      - /etc/resolv.conf:/etc/resolv.conf
+      - /run:/run
+      - /var/run:/var/run
+      - /var/tmp:/tmp
+      - /dev:/dev
+      - /sys:/sys
+      - /usr/local/bin/test.sh:/usr/local/bin/test.sh
+files:
+  - path: etc/docker/daemon.json
+    contents: '{"debug": true}'
+  - path: usr/local/bin/test.sh
+    contents: |
+      #!/bin/sh
+      set -eux
+      export PATH="$PATH:/usr/local/bin"
+      rm -rf /tmp/build
+      mkdir /tmp/build
+      cd /tmp/build
+      tar xf -
+      if [ -x ci-setup.sh ]; then ./ci-setup.sh; fi
+      make ci-pr
+    mode: "0755"
+trust:
+  org:
+    - linuxkit


### PR DESCRIPTION
This PR adds a worker.yml that defines the configuration of the linuxkit
workers. It adds a build-workers.sh script that will build and push a
linuxkit worker to GCP. Once pushed, the new image will be used.

Signed-off-by: Dave Tucker <dt@docker.com>