### PR TITLE
gcp: Try to enable nested virt on GCP

### DIFF
--- a/run-files/gcloud/create.py
+++ b/run-files/gcloud/create.py
@@ -17,6 +17,7 @@ logging.info("Using source disk image %s", source_disk_image)
 config = {
         'name': name,
         'machineType': 'zones/europe-west1-b/machineTypes/custom-2-5120',
+        'minCpuPlatform': 'Intel Haswell',
         'disks': [
             {
                 'boot': True,


### PR DESCRIPTION
See: https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances

resolves #https://github.com/linuxkit/linuxkit/issues/2696

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>