### PR TITLE
Update for new GCP hosting and maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ To use Google Compute for testing:
 
 ### Deploying to production
 
-You need access to the `editions/datakit-ci` swarm, which is controlled by the `editions/datakitciadmins`
-team list currently.
+You need access to the `moby-datakit-ci` GCP project.
+The CI runs on the machine named `ci-manager`.
 
 If you change `prod.yml`, run `./deploy-prod.sh` to update the deployed services.
 

--- a/prod.yml
+++ b/prod.yml
@@ -53,12 +53,6 @@ volumes:
   datakit-ssh:
     external:
       name: self-ci_datakit-ssh
-  talex5-ci-key:
-    external:
-      name: private_talex5-ci-key
-  fixed-builder-ssh:
-    external:
-      name: private_gce-key
   docker-hub-secrets:
     external:
       name: private_docker-hub-secrets

--- a/push.sh
+++ b/push.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -eux
 set -eux
-make docker DOCKER_HOST=unix:///var/run/docker.sock
-docker -H unix:///var/run/docker.sock push linuxkitci/ci
-IMAGE=$(docker -H unix:///var/run/docker.sock image inspect linuxkitci/ci -f '{{index .RepoDigests 0}}')
+LOCAL_DOCKER="DOCKER_HOST=unix:///var/run/docker.sock DOCKER_TLS_VERIFY="
+make docker $LOCAL_DOCKER
+env $LOCAL_DOCKER docker push linuxkitci/ci
+IMAGE=$(env $LOCAL_DOCKER docker image inspect linuxkitci/ci -f '{{index .RepoDigests 0}}')
 docker service update linuxkit_ci --image $IMAGE

--- a/src/ci.ml
+++ b/src/ci.ml
@@ -107,6 +107,8 @@ let can_build =
     any [
       username "admin";
       username "github:samoht";
+      username "github:djs55";
+      username "github:justincormack";
       username "github:rn";
       username "github:ijc";
       username "github:deitch";


### PR DESCRIPTION
- Docker Cloud is gone; use GCP hosting instead.
- Update admin list.
- Remove some unused volumes.

Also, it seems we need to unset `DOCKER_TLS_VERIFY` when using a socket now, otherwise the `push.sh`
script fails with:

    error during connect:
      Get https://%2Fvar%2Frun%2Fdocker.sock/v1.38/services:
        dial tcp: lookup /var/run/docker.sock: no such host

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>