### PR TITLE
Ensure oauth2client is installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apk update && apk add \
 
 RUN pip install google-api-python-client
 RUN pip install google-cloud-storage
+RUN pip install oauth2client
 
 RUN wget https://github.com/docker/notary/releases/download/v0.4.3/notary-Linux-amd64 -O /usr/local/bin/notary
 RUN echo '06cd02c4c2e7a3b1ad9899b03b3d4dde5392d964c675247d32f604a24661f839 */usr/local/bin/notary' | sha256sum -w -c -


### PR DESCRIPTION
Error was:

```
[2018-09-01 20:26.01] Running "/gcloud/destroy.py" "linuxkit-ci-0"
Traceback (most recent call last):
  File "/gcloud/destroy.py", line 3, in <module>
    import common
  File "/gcloud/common.py", line 3, in <module>
    from oauth2client.service_account import ServiceAccountCredentials
ImportError: No module named oauth2client.service_account
```

/cc @justincormack @rn